### PR TITLE
Create and update Smart Contract Wallet labels

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -3,6 +3,7 @@ export function Input({ error, ...props }) {
     <div className="flex flex-col w-full items-start">
       <input
         type="text"
+        autoComplete="do-not-autofill"
         className={`input input-bordered focus:input-primary input-lg rounded-full flex-grow font-mono text-center w-full text-lg ${
           error ? "input-error" : ""
         }`}

--- a/components/SCWCard.tsx
+++ b/components/SCWCard.tsx
@@ -52,7 +52,7 @@ export default function SCWCard({ address, title, onRefresh }: SCWCardProps) {
           <div className="card-body w-96 h-56 absolute backface-hidden">
             <h2 className="card-title flex space-x-2 items-center text-left my-3">
               <IconChip />
-              <p>{title || "Smart Contract Wallet"}</p>
+              <p>{title || walletInfo?.label || "Smart Contract Wallet"}</p>
             </h2>
 
             {loading ? (

--- a/components/SCWCreateForm.tsx
+++ b/components/SCWCreateForm.tsx
@@ -30,6 +30,7 @@ export default function SCWCreateForm({ onRefresh }: SCWCreateFormProps) {
   const [proxyInitialFunds, setProxyInitialFunds] = useState("");
   const [enableMultisig, setEnableMultisig] = useState(false);
   const [multisigThreshold, setMultisigThreshold] = useState(1);
+  const [label, setLabel] = useState("");
 
   const { getValueValidationError, getArrayValidationError, checkValidationErrors } = useValidationErrors({
     validators: [
@@ -87,6 +88,12 @@ export default function SCWCreateForm({ onRefresh }: SCWCreateFormProps) {
         message: "Relayer addresses must be unique",
         validate: (r1, i) => !relayers.some((r2, j) => i !== j && r1 === r2),
       },
+      {
+        key: "label",
+        value: label,
+        message: "This field is mandatory",
+        validate: () => !!label,
+      },
     ],
   });
 
@@ -113,6 +120,7 @@ export default function SCWCreateForm({ onRefresh }: SCWCreateFormProps) {
     createProxyWallet(
       signingClient!,
       walletAddress,
+      label,
       guardians,
       relayers,
       parseFloat(proxyInitialFunds),
@@ -261,6 +269,14 @@ export default function SCWCreateForm({ onRefresh }: SCWCreateFormProps) {
       </button>
 
       <h2 className="text-3xl font-bold my-5">3. Create your wallet</h2>
+      <div className="w-full max-w-xl mb-2">
+        <Input
+          placeholder={`Label (e.g. Personal Wallet, Business Wallet...)`}
+          onChange={(event) => setLabel(event.target.value)}
+          error={getValueValidationError("label")}
+          value={label}
+        />
+      </div>
       <div className="flex flex-col md:flex-row w-full max-w-xl justify-between mb-8">
         <div className="flex flex-col items-start">
           <div className="relative rounded-full shadow-sm md:mr-2">

--- a/pages/wallets/index.tsx
+++ b/pages/wallets/index.tsx
@@ -30,7 +30,7 @@ const ListWallets: NextPage = () => {
           >
             {proxyWallets.map((address, i) => (
               <div key={i} className="m-5">
-                <SCWCard title={`Smart Contract Wallet`} address={address} onRefresh={refreshBalance} />
+                <SCWCard address={address} onRefresh={refreshBalance} />
               </div>
             ))}
           </div>

--- a/services/vectis.ts
+++ b/services/vectis.ts
@@ -45,6 +45,7 @@ export const SCWProposals = {
 export async function createProxyWallet(
   signingClient: SigningCosmWasmClient,
   userAddress: string,
+  label: string,
   guardians: string[],
   relayers: string[],
   proxyInitialFunds: number,
@@ -67,6 +68,7 @@ export async function createProxyWallet(
   // Create wallet message
   const createWalletMsg: CreateWalletMsg = {
     user_pubkey: account.pubkey?.value,
+    label: label,
     guardians: {
       addresses: guardians,
       ...(multisigThreshold && {

--- a/services/vectis.ts
+++ b/services/vectis.ts
@@ -391,3 +391,22 @@ export async function removeRelayerFromProxyWallet(
   const res = await proxyClient.removeRelayer({ relayerAddress });
   console.log(`Executed remove relayer transaction with hash ${res.transactionHash}. Logs:`, res.logs);
 }
+
+/**
+ * Updates a proxy wallet's label.
+ *
+ * @param signingClient
+ * @param userAddress
+ * @param proxyWalletAddress
+ * @param newLabel
+ */
+export async function updateProxyWalletLabel(
+  signingClient: SigningCosmWasmClient,
+  userAddress: string,
+  proxyWalletAddress: string,
+  newLabel: string
+) {
+  const proxyClient = new ProxyClient(signingClient, userAddress, proxyWalletAddress);
+  const res = await proxyClient.updateLabel({ newLabel });
+  console.log(`Executed update label transaction with hash ${res.transactionHash}. Logs:`, res.logs);
+}

--- a/types/FactoryContract.ts
+++ b/types/FactoryContract.ts
@@ -13,6 +13,7 @@ export type Uint128 = string;
 export type Binary = string;
 export interface CreateWalletMsg {
   guardians: Guardians;
+  label: string;
   proxy_initial_funds: Coin[];
   relayers: string[];
   user_pubkey: Binary;
@@ -90,6 +91,7 @@ export interface WalletInfo {
   code_id: number;
   guardians: Addr[];
   is_frozen: boolean;
+  label: string;
   multisig_address?: Addr | null;
   multisig_code_id: number;
   nonce: number;
@@ -215,6 +217,18 @@ export interface FactoryInterface extends FactoryReadOnlyInterface {
     memo?: string,
     funds?: readonly Coin[]
   ) => Promise<ExecuteResult>;
+  updateProxyUser: (
+    {
+      newUser,
+      oldUser,
+    }: {
+      newUser: Addr;
+      oldUser: Addr;
+    },
+    fee?: number | StdFee | "auto",
+    memo?: string,
+    funds?: readonly Coin[]
+  ) => Promise<ExecuteResult>;
   migrateWallet: (
     {
       migrationMsg,
@@ -281,6 +295,7 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
     this.sender = sender;
     this.contractAddress = contractAddress;
     this.createWallet = this.createWallet.bind(this);
+    this.updateProxyUser = this.updateProxyUser.bind(this);
     this.migrateWallet = this.migrateWallet.bind(this);
     this.updateCodeId = this.updateCodeId.bind(this);
     this.updateWalletFee = this.updateWalletFee.bind(this);
@@ -304,6 +319,32 @@ export class FactoryClient extends FactoryQueryClient implements FactoryInterfac
       {
         create_wallet: {
           create_wallet_msg: createWalletMsg,
+        },
+      },
+      fee,
+      memo,
+      funds
+    );
+  };
+  updateProxyUser = async (
+    {
+      newUser,
+      oldUser,
+    }: {
+      newUser: Addr;
+      oldUser: Addr;
+    },
+    fee: number | StdFee | "auto" = "auto",
+    memo?: string,
+    funds?: readonly Coin[]
+  ): Promise<ExecuteResult> => {
+    return await this.client.execute(
+      this.sender,
+      this.contractAddress,
+      {
+        update_proxy_user: {
+          new_user: newUser,
+          old_user: oldUser,
         },
       },
       fee,

--- a/types/ProxyContract.ts
+++ b/types/ProxyContract.ts
@@ -89,6 +89,7 @@ export interface InfoResponse {
   code_id: number;
   guardians: Addr[];
   is_frozen: boolean;
+  label: string;
   multisig_address?: Addr | null;
   multisig_code_id: number;
   nonce: number;
@@ -111,6 +112,7 @@ export interface InstantiateMsg {
 }
 export interface CreateWalletMsg {
   guardians: Guardians;
+  label: string;
   proxy_initial_funds: Coin[];
   relayers: string[];
   user_pubkey: Binary;
@@ -233,6 +235,16 @@ export interface ProxyInterface extends ProxyReadOnlyInterface {
     memo?: string,
     funds?: readonly Coin[]
   ) => Promise<ExecuteResult>;
+  updateLabel: (
+    {
+      newLabel,
+    }: {
+      newLabel: string;
+    },
+    fee?: number | StdFee | "auto",
+    memo?: string,
+    funds?: readonly Coin[]
+  ) => Promise<ExecuteResult>;
 }
 export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
   override client: SigningCosmWasmClient;
@@ -251,6 +263,7 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
     this.addRelayer = this.addRelayer.bind(this);
     this.removeRelayer = this.removeRelayer.bind(this);
     this.updateGuardians = this.updateGuardians.bind(this);
+    this.updateLabel = this.updateLabel.bind(this);
   }
 
   execute = async (
@@ -403,6 +416,29 @@ export class ProxyClient extends ProxyQueryClient implements ProxyInterface {
         update_guardians: {
           guardians,
           new_multisig_code_id: newMultisigCodeId,
+        },
+      },
+      fee,
+      memo,
+      funds
+    );
+  };
+  updateLabel = async (
+    {
+      newLabel,
+    }: {
+      newLabel: string;
+    },
+    fee: number | StdFee | "auto" = "auto",
+    memo?: string,
+    funds?: readonly Coin[]
+  ): Promise<ExecuteResult> => {
+    return await this.client.execute(
+      this.sender,
+      this.contractAddress,
+      {
+        update_label: {
+          new_label: newLabel,
         },
       },
       fee,


### PR DESCRIPTION
Smart Contract Wallets now **must** be created with a label (e.g. 'Personal Wallet', 'Business Wallet', etc...).
The label can be seen in the front of the card in SCW info page. By going into the _Manage_ section, a user can update the label, which must be different from the old label and a non-empty string to be valid.