### PR TITLE
feat: Various front-end adjustments

### DIFF
--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -1,47 +1,22 @@
 export function IconInfo() {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      className="stroke-current flex-shrink-0 w-6 h-6"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-      ></path>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="stroke-current flex-shrink-0 w-6 h-6">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
     </svg>
   );
 }
 
 export function IconSuccess() {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="stroke-current flex-shrink-0 h-6 w-6"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-      />
+    <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   );
 }
 
 export function IconWarning() {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="stroke-current flex-shrink-0 h-6 w-6"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -54,12 +29,7 @@ export function IconWarning() {
 
 export function IconError() {
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="stroke-current flex-shrink-0 h-6 w-6"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current flex-shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -150,6 +120,17 @@ export function IconCheckmark() {
           <path d="M9.86 18a1 1 0 0 1-.73-.32l-4.86-5.17a1 1 0 1 1 1.46-1.37l4.12 4.39 8.41-9.2a1 1 0 1 1 1.48 1.34l-9.14 10a1 1 0 0 1-.73.33z" />
         </g>
       </g>
+    </svg>
+  );
+}
+
+export function IconAdd() {
+  return (
+    <svg width="24px" height="24px" viewBox="0 0 490 490" fill={"#fff"}>
+      <polygon
+        points="222.031,490 267.969,490 267.969,267.969 490,267.969 490,222.031 267.969,222.031 267.969,0 222.031,0
+	222.031,222.031 0,222.031 0,267.969 222.031,267.969 "
+      />
     </svg>
   );
 }

--- a/components/SCWCard.tsx
+++ b/components/SCWCard.tsx
@@ -102,10 +102,10 @@ export default function SCWCard({ address, title, onRefresh }: SCWCardProps) {
                     className={`btn modal-button btn-sm ${walletInfo?.is_frozen ? "btn-disabled" : "btn-primary"}`}
                     onClick={() => setModalChargeOpen(true)}
                   >
-                    Charge
+                    Top-up
                   </label>
                   <Anchor className="btn btn-primary btn-sm" href={`/wallets/manage/${address}`}>
-                    Top-up
+                    Manage
                   </Anchor>
                 </div>
               </div>

--- a/components/SCWManageForm.tsx
+++ b/components/SCWManageForm.tsx
@@ -11,7 +11,7 @@ import {
   updateProxyWalletLabel,
 } from "services/vectis";
 import { AlertError, AlertSuccess } from "./Alert";
-import { IconCheckmark, IconInfo, IconTrash } from "./Icon";
+import { IconAdd, IconCheckmark, IconInfo, IconTrash } from "./Icon";
 import { Input } from "./Input";
 import Loader from "./Loader";
 
@@ -331,6 +331,15 @@ export default function SCWManageForm({ proxyWalletAddress, onRefresh }: SCWMana
             error={getGuardianArrayValidationError("guardians", i)}
             value={address}
           />
+          {i === guardians.length - 1 && (
+            <button
+              className="btn btn-primary btn-md font-semibold hover:text-base-100 text-lg rounded-full"
+              onClick={() => pushGuardian()}
+              type="button"
+            >
+              <IconAdd />
+            </button>
+          )}
           {guardians.length > 1 && (
             <button
               className="btn btn-primary btn-circle btn-xl font-semibold hover:text-base-100 text-xl"
@@ -342,13 +351,6 @@ export default function SCWManageForm({ proxyWalletAddress, onRefresh }: SCWMana
           )}
         </div>
       ))}
-      <button
-        className="btn btn-primary btn-md font-semibold hover:text-base-100 text-lg rounded-full"
-        onClick={() => pushGuardian()}
-        type="button"
-      >
-        ADD GUARDIAN
-      </button>
 
       <div className="form-control">
         <label className="label cursor-pointer">
@@ -412,7 +414,7 @@ export default function SCWManageForm({ proxyWalletAddress, onRefresh }: SCWMana
         </div>
       )}
 
-      <h2 className="text-3xl font-bold my-5">Update your relayers</h2>
+      {/* <h2 className="text-3xl font-bold my-5">Update your relayers</h2>
 
       {relayers.map((address, i) => (
         <div className="flex w-full max-w-xl align-middle items-center space-x-3 mb-2" key={i}>
@@ -447,7 +449,7 @@ export default function SCWManageForm({ proxyWalletAddress, onRefresh }: SCWMana
         type="button"
       >
         ADD RELAYER
-      </button>
+      </button> */}
 
       {updateRelayersError && (
         <div className="mt-4 mb-8 flex flex-col w-full max-w-xl">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,8 +15,8 @@ const Home: NextPage = () => {
       <Head>
         <title>Vectis</title>
       </Head>
-      <div className="flex flex-col justify-center items-center max-w-[80%]">
-        <h1 className="text-6xl font-bold">Welcome to Vectis!</h1>
+      <div className="flex flex-col justify-center items-center max-w-[50%]">
+        <h1 className="text-6xl font-bold text-center">Welcome to Vectis!</h1>
         <h2 className="text-xl my-5 text-center">
           A smart contract wallet project to help user manage their funds by allowing for social recovery and guardianship, whilst preserving
           user control. <br /> For more information, please see our{" "}

--- a/services/vectis.ts
+++ b/services/vectis.ts
@@ -83,8 +83,10 @@ export async function createProxyWallet(
       }),
     },
     relayers: relayers,
-    proxy_initial_funds: [coin(proxyInitialFunds)],
+    proxy_initial_funds: !!proxyInitialFunds ? [coin(proxyInitialFunds)] : [],
   };
+
+  console.log(createWalletMsg);
 
   // Execute wallet creation
   const res = await factoryClient.createWallet({ createWalletMsg }, "auto", undefined, [

--- a/services/vectis.ts
+++ b/services/vectis.ts
@@ -86,8 +86,6 @@ export async function createProxyWallet(
     proxy_initial_funds: !!proxyInitialFunds ? [coin(proxyInitialFunds)] : [],
   };
 
-  console.log(createWalletMsg);
-
   // Execute wallet creation
   const res = await factoryClient.createWallet({ createWalletMsg }, "auto", undefined, [
     coin(proxyInitialFunds + convertMicroDenomToDenom(defaultWalletCreationFee.amount)),

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.modal {
+  --tw-bg-opacity: 0.9;
+}


### PR DESCRIPTION
Various fixes and modifications requested by Belsy on Slack. Below a transcript:

1. Can we make the text align with the width of the 2 cards (image below)
2. After Delegation / Claim / etc  popup should then be hidden
3. Lets make Create wallet:
	  a. Choose your guardians
	  b. Label and fund your wallet
	  c. Coming soon - Set relayers  (disable button and text field)
	  d. Initial fund is optional - should be able to be empty
	  e. Tooltip next to Create button (“An additional <fee value> <network token> is charged in this transaction and transferred to the Vectis DAO”)
4. Wallet card: Top-up should be Manage
5. Wallet card: Charge should be Top-up
6. Vote Proposal Bug - https://github.com/nymlab/vectis_fe/issues/51
8. Vote Proposal Card: Execute Proposal
	  a. We need to fetch the proposal result without use “Refreshing the page” so that we can display the Proposal to freeze wallet has passed - click to execute
	  b. When Proposal to freeze wallet has passed - click to execute is showed, we should disable frontend Vote To Freeze until it has been execute. There is no way for us to pick which one to execute in the frontend at the moment. (edited) 